### PR TITLE
Detect Test Failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: python
 
 dist: xenial
 
+# safelist
+branches:
+  only:
+  - master
+
 # Define which python version to build against.
 # As blender comes bundled with it's own python you can use just one version if you like
 python:
@@ -52,3 +57,4 @@ install:
 
 # Finally start our test runner passing it the blender executable from the downloaded blender release
 script: python testrunner.py ./tmp/blender/blender
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ language: python
 
 dist: xenial
 
-# safelist
-branches:
-  only:
-  - master
-
 # Define which python version to build against.
 # As blender comes bundled with it's own python you can use just one version if you like
 python:
@@ -57,4 +52,3 @@ install:
 
 # Finally start our test runner passing it the blender executable from the downloaded blender release
 script: python testrunner.py ./tmp/blender/blender
-

--- a/testrunner.py
+++ b/testrunner.py
@@ -14,4 +14,8 @@ if len(sys.argv) > 1:
 # iterate over each *.test.blend file in the "tests" directory
 # and open up blender with the .test.blend file and the corresponding .test.py python script
 for file in glob.glob('tests/**/*.test.blend'):
-    subprocess.call([blenderExecutable, '--addons', 'phobos', '--factory-startup', '-noaudio', '-b', file, '--python', file.replace('.blend', '.py')])
+    code = subprocess.call([blenderExecutable, '--addons', 'phobos', '--factory-startup', '-noaudio', '-b', file, '--python', file.replace('.blend', '.py'), '--python-exit-code', '1'])
+    if code:
+        sys.exit(code)
+
+sys.exit(0)

--- a/tests/basics/basics.test.py
+++ b/tests/basics/basics.test.py
@@ -1,14 +1,18 @@
+import sys
 
-import unittest
-import phobos
+try:
+	import unittest
+	import phobos
 
-class TestPhobosAddon(unittest.TestCase):
+	class TestPhobosAddon(unittest.TestCase):
 
-    def test_addon_enabled(self):
-        # test if addon got loaded correctly
-        # every addon must provide the "bl_info" dict
-        self.assertIsNotNone(phobos.bl_info)
+		def test_addon_enabled(self):
+		    # test if addon got loaded correctly
+		    # every addon must provide the "bl_info" dict
+		    self.assertIsNotNone(phobos.bl_info)
 
-# we have to manually invoke the test runner here, as we cannot use the CLI
-suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestPhobosAddon)
-unittest.TextTestRunner().run(suite)
+	# we have to manually invoke the test runner here, as we cannot use the CLI
+	suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestPhobosAddon)
+	unittest.TextTestRunner().run(suite)
+except:
+	sys.exit(1)

--- a/tests/testmodel/testmodel.test.py
+++ b/tests/testmodel/testmodel.test.py
@@ -1,50 +1,55 @@
 #!/usr/bin/python3
 
-import bpy
-import phobos
-import unittest
+import sys
 
-class TestInertiaModel(unittest.TestCase):
+try:
+    import bpy
+    import phobos
+    import unittest
 
-    def test_calculateBoxInertia(self):
-        mass = 12
-        size = [1, 2, 3]
-        result = [13, 0, 0, 10, 0, 5]
+    class TestInertiaModel(unittest.TestCase):
 
-        self.assertEqual(phobos.model.inertia.calculateBoxInertia(mass, size), result)
+        def test_calculateBoxInertia(self):
+            mass = 12
+            size = [1, 2, 3]
+            result = [13, 0, 0, 10, 0, 5]
 
-    def test_calculateCylinderInertia(self):
-        mass = 12
-        radius = 2
-        height = 5
-        result = [37, 0, 0, 37, 0, 24]
+            self.assertEqual(phobos.model.inertia.calculateBoxInertia(mass, size), result)
 
-        self.assertEqual(phobos.model.inertia.calculateCylinderInertia(mass, radius, height), result)
+        def test_calculateCylinderInertia(self):
+            mass = 12
+            radius = 2
+            height = 5
+            result = [37, 0, 0, 37, 0, 24]
 
-    def test_calculateSphereInertia(self):
-        mass = 12
-        radius = 2
-        result = [19.2, 0, 0, 19.2, 0, 19.2]
+            self.assertEqual(phobos.model.inertia.calculateCylinderInertia(mass, radius, height), result)
 
-        self.assertEqual(phobos.model.inertia.calculateSphereInertia(mass, radius), result)
+        def test_calculateSphereInertia(self):
+            mass = 12
+            radius = 2
+            result = [19.2, 0, 0, 19.2, 0, 19.2]
 
-    def test_calculateEllipsoidInertia(self):
-        mass = 5
-        size = [1, 2, 3]
-        result = [13, 0, 0, 10, 0, 5]
+            self.assertEqual(phobos.model.inertia.calculateSphereInertia(mass, radius), result)
 
-        self.assertEqual(phobos.model.inertia.calculateEllipsoidInertia(mass, size), result)
+        def test_calculateEllipsoidInertia(self):
+            mass = 5
+            size = [1, 2, 3]
+            result = [13, 0, 0, 10, 0, 5]
 
-    def test_inertiaListToMatrix(self):
-        inertialist = [1, 2, 3, 4, 5, 6]
-        result = [[1, 2, 3], [2, 4, 5], [3, 5, 6]]
+            self.assertEqual(phobos.model.inertia.calculateEllipsoidInertia(mass, size), result)
 
-        self.assertEqual(phobos.model.inertia.inertiaListToMatrix(inertialist), result)
+        def test_inertiaListToMatrix(self):
+            inertialist = [1, 2, 3, 4, 5, 6]
+            result = [[1, 2, 3], [2, 4, 5], [3, 5, 6]]
 
-    def test_inertiaMatriToList(self):
-        matrix = [[1, 2, 3], [2, 4, 5], [3, 5, 6]]
-        result = [1, 2, 3, 4, 5, 6]
+            self.assertEqual(phobos.model.inertia.inertiaListToMatrix(inertialist), result)
 
-        self.assertEqual(phobos.model.inertia.inertiaMatrixToList(matrix), result)
+        def test_inertiaMatriToList(self):
+            matrix = [[1, 2, 3], [2, 4, 5], [3, 5, 6]]
+            result = [1, 2, 3, 4, 5, 6]
 
-        # TODO continue with joints
+            self.assertEqual(phobos.model.inertia.inertiaMatrixToList(matrix), result)
+
+            # TODO continue with joints
+except:
+    sys.exit(1)

--- a/tests/testutils/testutils.test.py
+++ b/tests/testutils/testutils.test.py
@@ -1,190 +1,195 @@
 #!/usr/bin/python3
 
-import phobos
-import unittest
+import sys
 
-class TestBlenderUtils(unittest.TestCase):
+try:
+    import phobos
+    import unittest
 
-    def test_compileEnumPropertyList(self):
-        testlist = phobos.utils.blender.compileEnumPropertyList([1, 2, 3])
-        self.assertTupleEqual(testlist, ((1, 1, 1), (2, 2, 2), (3, 3, 3)))
+    class TestBlenderUtils(unittest.TestCase):
 
-class TestGeneralUtils(unittest.TestCase):
+        def test_compileEnumPropertyList(self):
+            testlist = phobos.utils.blender.compileEnumPropertyList([1, 2, 3])
+            self.assertTupleEqual(testlist, ((1, 1, 1), (2, 2, 2), (3, 3, 3)))
 
-    def test_is_float(self):
-        self.assertTrue(phobos.utils.general.is_float('12.3'))
-        self.assertFalse(phobos.utils.general.is_float('hello'))
-        self.assertFalse(phobos.utils.general.is_float('[12.3, 3.2]'))
+    class TestGeneralUtils(unittest.TestCase):
 
-    def test_is_int(self):
-        self.assertTrue(phobos.utils.general.is_int('12'))
-        self.assertFalse(phobos.utils.general.is_int('hello'))
-        self.assertFalse(phobos.utils.general.is_int('12.3452234'))
-        self.assertFalse(phobos.utils.general.is_int('[12, 3]'))
+        def test_is_float(self):
+            self.assertTrue(phobos.utils.general.is_float('12.3'))
+            self.assertFalse(phobos.utils.general.is_float('hello'))
+            self.assertFalse(phobos.utils.general.is_float('[12.3, 3.2]'))
 
-    def test_parse_number(self):
-        number = phobos.utils.general.parse_number('12')
-        self.assertEqual(type(number), type(1))
-        number = phobos.utils.general.parse_number('12.124')
-        self.assertEqual(type(number), type(12.124))
-        number = phobos.utils.general.parse_number('hello')
-        self.assertEqual(type(number), type('hello'))
+        def test_is_int(self):
+            self.assertTrue(phobos.utils.general.is_int('12'))
+            self.assertFalse(phobos.utils.general.is_int('hello'))
+            self.assertFalse(phobos.utils.general.is_int('12.3452234'))
+            self.assertFalse(phobos.utils.general.is_int('[12, 3]'))
 
-    def test_only_contains_int(self):
-        testlist = [1, 2, 3, 4, 5]
-        self.assertTrue(phobos.utils.general.only_contains_int(testlist))
-        testlist = [1, 2, 3, 4, 5, 12.3]
-        self.assertFalse(phobos.utils.general.only_contains_int(testlist))
-        testlist = [1, 2, 3, 4, 5, 'hello']
-        self.assertFalse(phobos.utils.general.only_contains_int(testlist))
+        def test_parse_number(self):
+            number = phobos.utils.general.parse_number('12')
+            self.assertEqual(type(number), type(1))
+            number = phobos.utils.general.parse_number('12.124')
+            self.assertEqual(type(number), type(12.124))
+            number = phobos.utils.general.parse_number('hello')
+            self.assertEqual(type(number), type('hello'))
 
-    def test_only_contains_float(self):
-        testlist = [1.1, 2.1, 3.5, 4.7, 5.6]
-        self.assertTrue(phobos.utils.general.only_contains_float(testlist))
-        testlist = [1.1, 2.1, 3.5, 4.7, 5.6, 12]
-        self.assertFalse(phobos.utils.general.only_contains_float(testlist))
-        testlist = [1.1, 2.1, 3.5, 4.7, 5.6, 'hello']
-        self.assertFalse(phobos.utils.general.only_contains_float(testlist))
+        def test_only_contains_int(self):
+            testlist = [1, 2, 3, 4, 5]
+            self.assertTrue(phobos.utils.general.only_contains_int(testlist))
+            testlist = [1, 2, 3, 4, 5, 12.3]
+            self.assertFalse(phobos.utils.general.only_contains_int(testlist))
+            testlist = [1, 2, 3, 4, 5, 'hello']
+            self.assertFalse(phobos.utils.general.only_contains_int(testlist))
 
-    def test_parse_text(self):
-        teststring = '1 2 3 4 5'
-        self.assertListEqual(phobos.utils.general.parse_text(teststring), [1, 2, 3, 4, 5])
-        teststring = '1.1 2.1 3.4 4.7 5.1'
-        self.assertListEqual(phobos.utils.general.parse_text(teststring), [1.1, 2.1, 3.4, 4.7, 5.1])
-        teststring = 'a bc de hello whatsoever'
-        self.assertListEqual(phobos.utils.general.parse_text(teststring), ['a', 'bc', 'de', 'hello', 'whatsoever'])
-        teststring = '12.3'
-        self.assertEqual(phobos.utils.general.parse_text(teststring), 12.3)
-        teststring = '12'
-        self.assertEqual(phobos.utils.general.parse_text(teststring), 12)
+        def test_only_contains_float(self):
+            testlist = [1.1, 2.1, 3.5, 4.7, 5.6]
+            self.assertTrue(phobos.utils.general.only_contains_float(testlist))
+            testlist = [1.1, 2.1, 3.5, 4.7, 5.6, 12]
+            self.assertFalse(phobos.utils.general.only_contains_float(testlist))
+            testlist = [1.1, 2.1, 3.5, 4.7, 5.6, 'hello']
+            self.assertFalse(phobos.utils.general.only_contains_float(testlist))
 
-    def test_calcBoundingBoxCenter(self):
-        corners = [
-            [0., 0., 0.],
-            [1., 0., 0.],
-            [1., 0., 1.],
-            [0., 0., 1.],
-            [0., 1., 0.],
-            [1., 1., 0.],
-            [1., 1., 1.],
-            [0., 1., 1.]
-        ]
-        self.assertEqual(phobos.utils.general.calcBoundingBoxCenter(corners), mathutils.Vector([0.5, 0.5, 0.5]))
+        def test_parse_text(self):
+            teststring = '1 2 3 4 5'
+            self.assertListEqual(phobos.utils.general.parse_text(teststring), [1, 2, 3, 4, 5])
+            teststring = '1.1 2.1 3.4 4.7 5.1'
+            self.assertListEqual(phobos.utils.general.parse_text(teststring), [1.1, 2.1, 3.4, 4.7, 5.1])
+            teststring = 'a bc de hello whatsoever'
+            self.assertListEqual(phobos.utils.general.parse_text(teststring), ['a', 'bc', 'de', 'hello', 'whatsoever'])
+            teststring = '12.3'
+            self.assertEqual(phobos.utils.general.parse_text(teststring), 12.3)
+            teststring = '12'
+            self.assertEqual(phobos.utils.general.parse_text(teststring), 12)
 
-        corners = [
-            [-1., -1., -1.],
-            [1., -1., -1.],
-            [1., -1., 1.],
-            [-1., -1., 1.],
-            [-1., 1., -1.],
-            [1., 1., -1.],
-            [1., 1., 1.],
-            [-1., 1., 1.]
-        ]
-        self.assertEqual(phobos.utils.general.calcBoundingBoxCenter(corners), mathutils.Vector([0., 0., 0.]))
+        def test_calcBoundingBoxCenter(self):
+            corners = [
+                [0., 0., 0.],
+                [1., 0., 0.],
+                [1., 0., 1.],
+                [0., 0., 1.],
+                [0., 1., 0.],
+                [1., 1., 0.],
+                [1., 1., 1.],
+                [0., 1., 1.]
+            ]
+            self.assertEqual(phobos.utils.general.calcBoundingBoxCenter(corners), mathutils.Vector([0.5, 0.5, 0.5]))
 
-    def test_sortListsInDict(self):
-        testdict = {'a': 1, 'b': [15, 12, 4, -3], 'c': ['delta', 'gamma', 'yota', 'omega'],
-                    'd': 'hello', 'e': [12.3, 14, 'meh']}
-        targetdict = {'a': 1, 'b': [15, 12, 4, -3], 'c': ['delta', 'gamma', 'omega', 'yota'],
-                      'd': 'hello', 'e': [12.3, 14, 'meh']}
-        self.assertEqual(phobos.utils.general.sortListsInDict(testdict), targetdict)
-        testdict = ['omega', 'delta', 'alpha', 'eta']
-        targetdict = ['alpha', 'delta', 'eta', 'omega']
-        self.assertListEqual(phobos.utils.general.sortListsInDict(testdict) ,targetdict)
-        testdict = ['omega', 'delta', 'alpha', 'eta']
-        targetdict = ['omega', 'eta', 'delta', 'alpha']
-        self.assertListEqual(phobos.utils.general.sortListsInDict(testdict, reverse=True) ,targetdict)
-        # TODO adjust docstring to include string only?
+            corners = [
+                [-1., -1., -1.],
+                [1., -1., -1.],
+                [1., -1., 1.],
+                [-1., -1., 1.],
+                [-1., 1., -1.],
+                [1., 1., -1.],
+                [1., 1., 1.],
+                [-1., 1., 1.]
+            ]
+            self.assertEqual(phobos.utils.general.calcBoundingBoxCenter(corners), mathutils.Vector([0., 0., 0.]))
 
-    def test_roundFloatsInDict(self):
-        testdict = {'a': 1, 'b': [12.545, -3.111, -3.894, 15.25, -0.111], 'c': ['delta', 'alpha', 'gamma']}
-        targetdict = {'a': 1, 'b': [13., -3., -4., 15., 0.], 'c': ['delta', 'alpha', 'gamma']}
-        self.assertEqual(phobos.utils.general.roundFloatsInDict(testdict, 0), targetdict)
-        targetdict = {'a': 1, 'b': [12.5, -3.1, -3.9, 15.3, -0.1], 'c': ['delta', 'alpha', 'gamma']}
-        self.assertEqual(phobos.utils.general.roundFloatsInDict(testdict, 1), targetdict)
-        targetdict = {'a': 1, 'b': [12.55, -3.11, -3.89, 15.25, -0.11], 'c': ['delta', 'alpha', 'gamma']}
-        self.assertEqual(phobos.utils.general.roundFloatsInDict(testdict, 2), targetdict)
+        def test_sortListsInDict(self):
+            testdict = {'a': 1, 'b': [15, 12, 4, -3], 'c': ['delta', 'gamma', 'yota', 'omega'],
+                        'd': 'hello', 'e': [12.3, 14, 'meh']}
+            targetdict = {'a': 1, 'b': [15, 12, 4, -3], 'c': ['delta', 'gamma', 'omega', 'yota'],
+                          'd': 'hello', 'e': [12.3, 14, 'meh']}
+            self.assertEqual(phobos.utils.general.sortListsInDict(testdict), targetdict)
+            testdict = ['omega', 'delta', 'alpha', 'eta']
+            targetdict = ['alpha', 'delta', 'eta', 'omega']
+            self.assertListEqual(phobos.utils.general.sortListsInDict(testdict) ,targetdict)
+            testdict = ['omega', 'delta', 'alpha', 'eta']
+            targetdict = ['omega', 'eta', 'delta', 'alpha']
+            self.assertListEqual(phobos.utils.general.sortListsInDict(testdict, reverse=True) ,targetdict)
+            # TODO adjust docstring to include string only?
 
-    def test_datetimeFromIso(self):
-        # TODO add test case for ISO time
-        pass
+        def test_roundFloatsInDict(self):
+            testdict = {'a': 1, 'b': [12.545, -3.111, -3.894, 15.25, -0.111], 'c': ['delta', 'alpha', 'gamma']}
+            targetdict = {'a': 1, 'b': [13., -3., -4., 15., 0.], 'c': ['delta', 'alpha', 'gamma']}
+            self.assertEqual(phobos.utils.general.roundFloatsInDict(testdict, 0), targetdict)
+            targetdict = {'a': 1, 'b': [12.5, -3.1, -3.9, 15.3, -0.1], 'c': ['delta', 'alpha', 'gamma']}
+            self.assertEqual(phobos.utils.general.roundFloatsInDict(testdict, 1), targetdict)
+            targetdict = {'a': 1, 'b': [12.55, -3.11, -3.89, 15.25, -0.11], 'c': ['delta', 'alpha', 'gamma']}
+            self.assertEqual(phobos.utils.general.roundFloatsInDict(testdict, 2), targetdict)
 
-    def test_outerProduct(self):
-        a = [0, 1, 2]
-        b = [3, 4, 5]
-        result = [[4, 5, 6], [8, 10, 12], [12, 15, 18]]
-        self.assertEqual(phobos.utils.general.outerProduct(a, b), result)
+        def test_datetimeFromIso(self):
+            # TODO add test case for ISO time
+            pass
 
-class TestIOUtils(unittest.TestCase):
+        def test_outerProduct(self):
+            a = [0, 1, 2]
+            b = [3, 4, 5]
+            result = [[4, 5, 6], [8, 10, 12], [12, 15, 18]]
+            self.assertEqual(phobos.utils.general.outerProduct(a, b), result)
 
-    def test_xmlline(self):
-        tag = 'helloworld'
-        names = ['number', 'name', 'stuff']
-        values = [12.3, 'bert', ['a', 'b', 'c']]
-        target = '<helloworld number="12.3" name="bert" stuff="[{0}, {1}, {2}]"/>\n'.format("'a'", "'b'", "'c'")
+    class TestIOUtils(unittest.TestCase):
 
-        self.assertEqual(phobos.utils.io.xmlline(0, tag, names, values), target)
-        self.assertEqual(phobos.utils.io.xmlline(3, tag, names, values), "   " + target)
+        def test_xmlline(self):
+            tag = 'helloworld'
+            names = ['number', 'name', 'stuff']
+            values = [12.3, 'bert', ['a', 'b', 'c']]
+            target = '<helloworld number="12.3" name="bert" stuff="[{0}, {1}, {2}]"/>\n'.format("'a'", "'b'", "'c'")
 
-    def test_l2str(self):
-        testlist = [1, 2, 'hello', '-1']
-        target = '1 2 hello -1'
-        self.assertEqual(phobos.utils.io.l2str(testlist), target)
-        target = '2 hello -1'
-        self.assertEqual(phobos.utils.io.l2str(testlist, start=1), target)
-        target = '2 hello'
-        self.assertEqual(phobos.utils.io.l2str(testlist, start=1, end=-2), target)
-        target = ''
-        self.assertEqual(phobos.utils.io.l2str(testlist, start=5, end=-8), target)
+            self.assertEqual(phobos.utils.io.xmlline(0, tag, names, values), target)
+            self.assertEqual(phobos.utils.io.xmlline(3, tag, names, values), "   " + target)
 
-class TestNamingUtils(unittest.TestCase):
+        def test_l2str(self):
+            testlist = [1, 2, 'hello', '-1']
+            target = '1 2 hello -1'
+            self.assertEqual(phobos.utils.io.l2str(testlist), target)
+            target = '2 hello -1'
+            self.assertEqual(phobos.utils.io.l2str(testlist, start=1), target)
+            target = '2 hello'
+            self.assertEqual(phobos.utils.io.l2str(testlist, start=1, end=-2), target)
+            target = ''
+            self.assertEqual(phobos.utils.io.l2str(testlist, start=5, end=-8), target)
 
-    def test_getUniqueName(self):
-        testname = 'bert'
-        testlist = ['gunther', 'bert', 'walter']
-        target = 'bert.001'
-        self.assertEqual(phobos.utils.naming.getUniqueName(testname, testlist), target)
+    class TestNamingUtils(unittest.TestCase):
 
-        testname = 'b' * 70
-        testlist = ['gunther', 'b' * 70, 'walter']
-        target = 'b' * 59 + '.001'
-        self.assertEqual(phobos.utils.naming.getUniqueName(testname, testlist), target)
+        def test_getUniqueName(self):
+            testname = 'bert'
+            testlist = ['gunther', 'bert', 'walter']
+            target = 'bert.001'
+            self.assertEqual(phobos.utils.naming.getUniqueName(testname, testlist), target)
 
-    def test_isValidModelname(self):
-        testname = 'helloworld'
-        self.assertTrue(phobos.utils.naming.isValidModelname(testname))
-        testname = '124%£DJFLL:'
-        self.assertFalse(phobos.utils.naming.isValidModelname(testname))
-        testname = 'asnd_123_ppja-'
-        self.assertFalse(phobos.utils.naming.isValidModelname(testname))
+            testname = 'b' * 70
+            testlist = ['gunther', 'b' * 70, 'walter']
+            target = 'b' * 59 + '.001'
+            self.assertEqual(phobos.utils.naming.getUniqueName(testname, testlist), target)
 
-    def test_addNamespaceToName(self):
-        testname = 'bert'
-        namespace = 'robot'
-        target = 'robot::bert'
-        self.assertEqual(phobos.utils.naming.addNamespaceToName(testname, namespace), target)
-        testname = 'robot::bert'
-        namespace = 'model'
-        target = 'model::robot::bert'
-        self.assertEqual(phobos.utils.naming.addNamespaceToName(testname, namespace), target)
+        def test_isValidModelname(self):
+            testname = 'helloworld'
+            self.assertTrue(phobos.utils.naming.isValidModelname(testname))
+            testname = '124%£DJFLL:'
+            self.assertFalse(phobos.utils.naming.isValidModelname(testname))
+            testname = 'asnd_123_ppja-'
+            self.assertFalse(phobos.utils.naming.isValidModelname(testname))
 
-    def test_stripNamespaceFromName(self):
-        testname = 'robot::bert'
-        target = 'bert'
-        self.assertEqual(phobos.utils.naming.stripNamespaceFromName(testname), target)
-        testname = 'model::robot::bert'
-        target = 'robot::bert'
-        self.assertEqual(phobos.utils.naming.stripNamespaceFromName(testname), target)
+        def test_addNamespaceToName(self):
+            testname = 'bert'
+            namespace = 'robot'
+            target = 'robot::bert'
+            self.assertEqual(phobos.utils.naming.addNamespaceToName(testname, namespace), target)
+            testname = 'robot::bert'
+            namespace = 'model'
+            target = 'model::robot::bert'
+            self.assertEqual(phobos.utils.naming.addNamespaceToName(testname, namespace), target)
+
+        def test_stripNamespaceFromName(self):
+            testname = 'robot::bert'
+            target = 'bert'
+            self.assertEqual(phobos.utils.naming.stripNamespaceFromName(testname), target)
+            testname = 'model::robot::bert'
+            target = 'robot::bert'
+            self.assertEqual(phobos.utils.naming.stripNamespaceFromName(testname), target)
 
 
-# we have to manually invoke the test runner here, as we cannot use the CLI
-blenderutilstest = unittest.defaultTestLoader.loadTestsFromTestCase(TestBlenderUtils)
-generalutilstest = unittest.defaultTestLoader.loadTestsFromTestCase(TestGeneralUtils)
-ioutilstest = unittest.defaultTestLoader.loadTestsFromTestCase(TestIOUtils)
-namingutilstest = unittest.defaultTestLoader.loadTestsFromTestCase(TestNamingUtils)
+    # we have to manually invoke the test runner here, as we cannot use the CLI
+    blenderutilstest = unittest.defaultTestLoader.loadTestsFromTestCase(TestBlenderUtils)
+    generalutilstest = unittest.defaultTestLoader.loadTestsFromTestCase(TestGeneralUtils)
+    ioutilstest = unittest.defaultTestLoader.loadTestsFromTestCase(TestIOUtils)
+    namingutilstest = unittest.defaultTestLoader.loadTestsFromTestCase(TestNamingUtils)
 
-unittest.TextTestRunner().run(blenderutilstest)
-unittest.TextTestRunner().run(generalutilstest)
-unittest.TextTestRunner().run(ioutilstest)
-unittest.TextTestRunner().run(namingutilstest)
+    unittest.TextTestRunner().run(blenderutilstest)
+    unittest.TextTestRunner().run(generalutilstest)
+    unittest.TextTestRunner().run(ioutilstest)
+    unittest.TextTestRunner().run(namingutilstest)
+except:
+    sys.exit(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
To catch failures in the test suite, the exit code of each test is checked.

## Description
<!--- Describe your changes in detail -->
An additional option, `--python-exit-code 1` is added to the `subprocess.call` command. With some additional code in each test script, this allows the main script to detect when the test has failed.

